### PR TITLE
blob_test.go, func TestGetBlobProperies: rename func to TestGetBlobPrope...

### DIFF
--- a/clients/storage/blob_test.go
+++ b/clients/storage/blob_test.go
@@ -462,7 +462,7 @@ func TestDeleteBlobIfExists(t *testing.T) {
 	}
 }
 
-func TestGetBlobProperies(t *testing.T) {
+func TestGetBlobProperties(t *testing.T) {
 	cnt := randContainer()
 	blob := randString(20)
 	contents := randString(64)
@@ -474,8 +474,9 @@ func TestGetBlobProperies(t *testing.T) {
 
 	err = cli.CreateContainer(cnt, ContainerAccessTypePrivate)
 	if err != nil {
-		t.Fatal("Nonexisting blob did not return error")
+		t.Fatal(err)
 	}
+	defer cli.DeleteContainer(cnt)
 
 	// Nonexisting blob
 	_, err = cli.GetBlobProperties(cnt, blob)


### PR DESCRIPTION
...r*t*ies,

and add missing cleanup (cli.DeleteContainer()).

**Btw**, I have one question about the error message on line 477: is it correct? I assume it should be saying something like "Error creating test container" instead?

Code in question:
```
475     err = cli.CreateContainer(cnt, ContainerAccessTypePrivate)
476     if err != nil {
477         t.Fatal("Nonexisting blob did not return error")
478     }
```