### PR TITLE
Simple support for Page Blobs

### DIFF
--- a/clients/storage/blob.go
+++ b/clients/storage/blob.go
@@ -704,7 +704,6 @@ func (b BlobStorageClient) PutPage(container, name string, startByte, endByte in
 // GetPageRanges returns the list of valid page ranges for a page blob.
 // See https://msdn.microsoft.com/en-us/library/azure/ee691973.aspx
 func (b BlobStorageClient) GetPageRanges(container, name string) (GetPageRangesResponse, error) {
-	// TODO(ahmetb) add x-ms-range support
 	path := fmt.Sprintf("%s/%s", container, name)
 	uri := b.client.getEndpoint(blobServiceName, path, url.Values{"comp": {"pagelist"}})
 	headers := b.client.getStandardHeaders()


### PR DESCRIPTION
Here is simple support for page blobs. (contains a few other minor fixes I just noticed)

Does not contain anything related to page blob sequence numbers (implementation omitted as it's not a current need for docker-registry azure storage driver).

cc: @paulmey @snesha @sachin-jayant-joshi