### PR TITLE
Travis-CI support for storage client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: go
+go: tip
+script: go test -v ./clients/storage


### PR DESCRIPTION
Set up CI for storage client code to run existing test suite we have. See test results here: https://travis-ci.org/ahmetalpbalkan/azure-sdk-for-go/builds/48724492

This system uses storage keys set up on Travis-CI side and they're injected to the test container before test runs. Additional setup will be required by the repo admins to enable CI for the repo on http://travis-ci.org and setting private environment variables about the storage account from settings section of Travis-CI. 

This will help us understand if the PRs sent are breaking the code.
Please reach me out in setting up the CI on travis-ci, I can provide hands on help.
cc: @jeffmendoza @hopetobelievein @paulmey