### PR TITLE
Include the available role sizes from locations

### DIFF
--- a/clients/locationClient/entities.go
+++ b/clients/locationClient/entities.go
@@ -11,7 +11,9 @@ type LocationList struct {
 }
 
 type Location struct {
-	Name              string
-	DisplayName       string
-	AvailableServices []string `xml:"AvailableServices>AvailableService"`
+	Name                    string
+	DisplayName             string
+	AvailableServices       []string `xml:"AvailableServices>AvailableService"`
+	WebWorkerRoleSizes      []string `xml:"ComputeCapabilities>WebWorkerRoleSizes>RoleSize"`
+	VirtualMachineRoleSizes []string `xml:"ComputeCapabilities>VirtualMachineRoleSizes>RoleSize"`
 }


### PR DESCRIPTION
Previously the locations client did not return information about the available role sizes in each location. This commit adds two additional properties to the LocationList type to expose a list of Web/Worker role sizes and VM sizes available per region. Since the data is already returned by the API endpoint no API call changes are required.