### PR TITLE
Fix XML path to Virtual Machines Roles Sizes

### DIFF
--- a/clients/locationClient/entities.go
+++ b/clients/locationClient/entities.go
@@ -15,5 +15,5 @@ type Location struct {
 	DisplayName             string
 	AvailableServices       []string `xml:"AvailableServices>AvailableService"`
 	WebWorkerRoleSizes      []string `xml:"ComputeCapabilities>WebWorkerRoleSizes>RoleSize"`
-	VirtualMachineRoleSizes []string `xml:"ComputeCapabilities>VirtualMachineRoleSizes>RoleSize"`
+	VirtualMachineRoleSizes []string `xml:"ComputeCapabilities>VirtualMachinesRoleSizes>RoleSize"`
 }


### PR DESCRIPTION
The previous commit for this had a misspelling of VirtualMachinesRolesSizes for VirtualMachineRoleSizes (I assumed the XML naming would be consistent between Web/Worker roles and VMs!).

Is there a policy for how to write unit tests for this kind of stuff? Seems we'd need some kind of test Azure account for them to be able to run in CI?