### PR TITLE
Add check of availability of VM role size in location

### DIFF
--- a/clients/locationClient/locationClient.go
+++ b/clients/locationClient/locationClient.go
@@ -55,3 +55,29 @@ func GetLocationList() (LocationList, error) {
 
 	return locationList, nil
 }
+
+func GetLocation(location string) (*Location, error) {
+	if len(location) == 0 {
+		return nil, fmt.Errorf(azure.ParamNotSpecifiedError, "location")
+	}
+
+	locations, err := GetLocationList()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, existingLocation := range locations.Locations {
+		if existingLocation.Name != location {
+			continue
+		}
+
+		return &existingLocation, nil
+	}
+
+	var availableLocations bytes.Buffer
+	for _, existingLocation := range locations.Locations {
+		availableLocations.WriteString(existingLocation.Name + ", ")
+	}
+
+	return nil, errors.New(fmt.Sprintf(invalidLocationError, location, strings.Trim(availableLocations.String(), ", ")))
+}


### PR DESCRIPTION
There was previously nothing to prevent creation of a virtual machine of an instance size which was unavailable in a given location - instead the operation completed and getting the status returned a `ResourceNotFound` error. This pull request makes the following changes:

- Add a `GetLocation` function to the `locationClient` in order to get access to the structure without iterating through the list returned from `GetLocationList` in multiple spots.
- Remove the call to verify the instance size against the global list.
- Add a function `verifyInstanceSizeAvailableInLocation` to the `vmClient` and call this in place of verification against the global list.