### PR TITLE
Make azure.ParamNotSpecifiedError unexported

### DIFF
--- a/clients/hostedServiceClient/hostedServiceClient.go
+++ b/clients/hostedServiceClient/hostedServiceClient.go
@@ -18,15 +18,16 @@ const (
 	azureDeploymentURL                = "services/hostedservices/%s/deployments/%s"
 	deleteAzureDeploymentURL          = "services/hostedservices/%s/deployments/%s?comp=media"
 
-	invalidDnsLengthError = "The DNS name must be between 3 and 25 characters."
+	invalidDnsLengthError  = "The DNS name must be between 3 and 25 characters."
+	paramNotSpecifiedError = "Parameter %s is not specified."
 )
 
 func CreateHostedService(dnsName, location string, reverseDnsFqdn string) (string, error) {
 	if len(dnsName) == 0 {
-		return "", fmt.Errorf(azure.ParamNotSpecifiedError, "dnsName")
+		return "", fmt.Errorf(paramNotSpecifiedError, "dnsName")
 	}
 	if len(location) == 0 {
-		return "", fmt.Errorf(azure.ParamNotSpecifiedError, "location")
+		return "", fmt.Errorf(paramNotSpecifiedError, "location")
 	}
 
 	err := verifyDNSName(dnsName)
@@ -64,7 +65,7 @@ func CreateHostedService(dnsName, location string, reverseDnsFqdn string) (strin
 
 func CheckHostedServiceNameAvailability(dnsName string) (bool, string, error) {
 	if len(dnsName) == 0 {
-		return false, "", fmt.Errorf(azure.ParamNotSpecifiedError, "dnsName")
+		return false, "", fmt.Errorf(paramNotSpecifiedError, "dnsName")
 	}
 
 	err := verifyDNSName(dnsName)
@@ -89,7 +90,7 @@ func CheckHostedServiceNameAvailability(dnsName string) (bool, string, error) {
 
 func DeleteHostedService(dnsName string) error {
 	if len(dnsName) == 0 {
-		return fmt.Errorf(azure.ParamNotSpecifiedError, "dnsName")
+		return fmt.Errorf(paramNotSpecifiedError, "dnsName")
 	}
 
 	err := verifyDNSName(dnsName)

--- a/clients/imageClient/imageClient.go
+++ b/clients/imageClient/imageClient.go
@@ -8,8 +8,9 @@ import (
 )
 
 const (
-	azureImageListURL = "services/images"
-	invalidImageError = "Can not find image %s in specified subscription, please specify another image name."
+	azureImageListURL      = "services/images"
+	invalidImageError      = "Can not find image %s in specified subscription, please specify another image name."
+	paramNotSpecifiedError = "Parameter %s is not specified."
 )
 
 func GetImageList() (ImageList, error) {
@@ -24,13 +25,13 @@ func GetImageList() (ImageList, error) {
 	if err != nil {
 		return imageList, err
 	}
-	
+
 	return imageList, err
 }
 
 func ResolveImageName(imageName string) error {
 	if len(imageName) == 0 {
-		return fmt.Errorf(azure.ParamNotSpecifiedError, "imageName")
+		return fmt.Errorf(paramNotSpecifiedError, "imageName")
 	}
 
 	imageList, err := GetImageList()

--- a/clients/locationClient/locationClient.go
+++ b/clients/locationClient/locationClient.go
@@ -10,13 +10,14 @@ import (
 )
 
 const (
-	azureLocationListURL = "locations"
-	invalidLocationError = "Invalid location: %s. Available locations: %s"
+	azureLocationListURL   = "locations"
+	invalidLocationError   = "Invalid location: %s. Available locations: %s"
+	paramNotSpecifiedError = "Parameter %s is not specified."
 )
 
 func ResolveLocation(location string) error {
 	if len(location) == 0 {
-		return fmt.Errorf(azure.ParamNotSpecifiedError, "location")
+		return fmt.Errorf(paramNotSpecifiedError, "location")
 	}
 
 	locations, err := GetLocationList()
@@ -58,7 +59,7 @@ func GetLocationList() (LocationList, error) {
 
 func GetLocation(location string) (*Location, error) {
 	if len(location) == 0 {
-		return nil, fmt.Errorf(azure.ParamNotSpecifiedError, "location")
+		return nil, fmt.Errorf(paramNotSpecifiedError, "location")
 	}
 
 	locations, err := GetLocationList()

--- a/clients/storageServiceClient/storageServiceClient.go
+++ b/clients/storageServiceClient/storageServiceClient.go
@@ -15,6 +15,7 @@ const (
 	azureStorageServiceURL     = "services/storageservices/%s"
 
 	blobEndpointNotFoundError = "Blob endpoint was not found in storage serice %s"
+	paramNotSpecifiedError    = "Parameter %s is not specified."
 )
 
 func GetStorageServiceList() (*StorageServiceList, error) {
@@ -35,7 +36,7 @@ func GetStorageServiceList() (*StorageServiceList, error) {
 
 func GetStorageServiceByName(serviceName string) (*StorageService, error) {
 	if len(serviceName) == 0 {
-		return nil, fmt.Errorf(azure.ParamNotSpecifiedError, "serviceName")
+		return nil, fmt.Errorf(paramNotSpecifiedError, "serviceName")
 	}
 
 	storageService := new(StorageService)
@@ -55,7 +56,7 @@ func GetStorageServiceByName(serviceName string) (*StorageService, error) {
 
 func GetStorageServiceByLocation(location string) (*StorageService, error) {
 	if len(location) == 0 {
-		return nil, fmt.Errorf(azure.ParamNotSpecifiedError, "location")
+		return nil, fmt.Errorf(paramNotSpecifiedError, "location")
 	}
 
 	storageService := new(StorageService)
@@ -77,10 +78,10 @@ func GetStorageServiceByLocation(location string) (*StorageService, error) {
 
 func CreateStorageService(name, location string) (*StorageService, error) {
 	if len(name) == 0 {
-		return nil, fmt.Errorf(azure.ParamNotSpecifiedError, "name")
+		return nil, fmt.Errorf(paramNotSpecifiedError, "name")
 	}
 	if len(location) == 0 {
-		return nil, fmt.Errorf(azure.ParamNotSpecifiedError, "location")
+		return nil, fmt.Errorf(paramNotSpecifiedError, "location")
 	}
 
 	storageDeploymentConfig := createStorageServiceDeploymentConf(name, location)

--- a/clients/vmClient/vmClient.go
+++ b/clients/vmClient/vmClient.go
@@ -43,19 +43,20 @@ const (
 	invalidPasswordError               = "Password must have at least one upper case, lower case and numeric character."
 	invalidRoleSizeError               = "Invalid role size: %s. Available role sizes: %s"
 	invalidRoleSizeInLocationError     = "Role size: %s not available in location: %s."
+	paramNotSpecifiedError             = "Parameter %s is not specified."
 )
 
 //Region public methods starts
 
 func CreateAzureVM(azureVMConfiguration *Role, dnsName, location string) error {
 	if azureVMConfiguration == nil {
-		return fmt.Errorf(azure.ParamNotSpecifiedError, "azureVMConfiguration")
+		return fmt.Errorf(paramNotSpecifiedError, "azureVMConfiguration")
 	}
 	if len(dnsName) == 0 {
-		return fmt.Errorf(azure.ParamNotSpecifiedError, "dnsName")
+		return fmt.Errorf(paramNotSpecifiedError, "dnsName")
 	}
 	if len(location) == 0 {
-		return fmt.Errorf(azure.ParamNotSpecifiedError, "location")
+		return fmt.Errorf(paramNotSpecifiedError, "location")
 	}
 
 	err := verifyDNSname(dnsName)
@@ -99,16 +100,16 @@ func CreateAzureVM(azureVMConfiguration *Role, dnsName, location string) error {
 
 func CreateAzureVMConfiguration(dnsName, instanceSize, imageName, location string) (*Role, error) {
 	if len(dnsName) == 0 {
-		return nil, fmt.Errorf(azure.ParamNotSpecifiedError, "dnsName")
+		return nil, fmt.Errorf(paramNotSpecifiedError, "dnsName")
 	}
 	if len(instanceSize) == 0 {
-		return nil, fmt.Errorf(azure.ParamNotSpecifiedError, "instanceSize")
+		return nil, fmt.Errorf(paramNotSpecifiedError, "instanceSize")
 	}
 	if len(imageName) == 0 {
-		return nil, fmt.Errorf(azure.ParamNotSpecifiedError, "imageName")
+		return nil, fmt.Errorf(paramNotSpecifiedError, "imageName")
 	}
 	if len(location) == 0 {
-		return nil, fmt.Errorf(azure.ParamNotSpecifiedError, "location")
+		return nil, fmt.Errorf(paramNotSpecifiedError, "location")
 	}
 
 	err := verifyDNSname(dnsName)
@@ -140,10 +141,10 @@ func CreateAzureVMConfiguration(dnsName, instanceSize, imageName, location strin
 
 func AddAzureLinuxProvisioningConfig(azureVMConfiguration *Role, userName, password, certPath string, sshPort int) (*Role, error) {
 	if azureVMConfiguration == nil {
-		return nil, fmt.Errorf(azure.ParamNotSpecifiedError, "azureVMConfiguration")
+		return nil, fmt.Errorf(paramNotSpecifiedError, "azureVMConfiguration")
 	}
 	if len(userName) == 0 {
-		return nil, fmt.Errorf(azure.ParamNotSpecifiedError, "userName")
+		return nil, fmt.Errorf(paramNotSpecifiedError, "userName")
 	}
 
 	configurationSets := ConfigurationSets{}
@@ -173,19 +174,19 @@ func AddAzureLinuxProvisioningConfig(azureVMConfiguration *Role, userName, passw
 
 func SetAzureVMExtension(azureVMConfiguration *Role, name string, publisher string, version string, referenceName string, state string, publicConfigurationValue string, privateConfigurationValue string) (*Role, error) {
 	if azureVMConfiguration == nil {
-		return nil, fmt.Errorf(azure.ParamNotSpecifiedError, "azureVMConfiguration")
+		return nil, fmt.Errorf(paramNotSpecifiedError, "azureVMConfiguration")
 	}
 	if len(name) == 0 {
-		return nil, fmt.Errorf(azure.ParamNotSpecifiedError, "name")
+		return nil, fmt.Errorf(paramNotSpecifiedError, "name")
 	}
 	if len(publisher) == 0 {
-		return nil, fmt.Errorf(azure.ParamNotSpecifiedError, "publisher")
+		return nil, fmt.Errorf(paramNotSpecifiedError, "publisher")
 	}
 	if len(version) == 0 {
-		return nil, fmt.Errorf(azure.ParamNotSpecifiedError, "version")
+		return nil, fmt.Errorf(paramNotSpecifiedError, "version")
 	}
 	if len(referenceName) == 0 {
-		return nil, fmt.Errorf(azure.ParamNotSpecifiedError, "referenceName")
+		return nil, fmt.Errorf(paramNotSpecifiedError, "referenceName")
 	}
 
 	extension := ResourceExtensionReference{}
@@ -220,7 +221,7 @@ func SetAzureVMExtension(azureVMConfiguration *Role, name string, publisher stri
 
 func SetAzureDockerVMExtension(azureVMConfiguration *Role, dockerPort int, version string) (*Role, error) {
 	if azureVMConfiguration == nil {
-		return nil, fmt.Errorf(azure.ParamNotSpecifiedError, "azureVMConfiguration")
+		return nil, fmt.Errorf(paramNotSpecifiedError, "azureVMConfiguration")
 	}
 
 	if len(version) == 0 {
@@ -245,10 +246,10 @@ func SetAzureDockerVMExtension(azureVMConfiguration *Role, dockerPort int, versi
 
 func GetVMDeployment(cloudserviceName, deploymentName string) (*VMDeployment, error) {
 	if len(cloudserviceName) == 0 {
-		return nil, fmt.Errorf(azure.ParamNotSpecifiedError, "cloudserviceName")
+		return nil, fmt.Errorf(paramNotSpecifiedError, "cloudserviceName")
 	}
 	if len(deploymentName) == 0 {
-		return nil, fmt.Errorf(azure.ParamNotSpecifiedError, "deploymentName")
+		return nil, fmt.Errorf(paramNotSpecifiedError, "deploymentName")
 	}
 
 	deployment := new(VMDeployment)
@@ -269,10 +270,10 @@ func GetVMDeployment(cloudserviceName, deploymentName string) (*VMDeployment, er
 
 func DeleteVMDeployment(cloudserviceName, deploymentName string) error {
 	if len(cloudserviceName) == 0 {
-		return fmt.Errorf(azure.ParamNotSpecifiedError, "cloudserviceName")
+		return fmt.Errorf(paramNotSpecifiedError, "cloudserviceName")
 	}
 	if len(deploymentName) == 0 {
-		return fmt.Errorf(azure.ParamNotSpecifiedError, "deploymentName")
+		return fmt.Errorf(paramNotSpecifiedError, "deploymentName")
 	}
 
 	requestURL := fmt.Sprintf(deleteAzureDeploymentURL, cloudserviceName, deploymentName)
@@ -288,13 +289,13 @@ func DeleteVMDeployment(cloudserviceName, deploymentName string) error {
 
 func GetRole(cloudserviceName, deploymentName, roleName string) (*Role, error) {
 	if len(cloudserviceName) == 0 {
-		return nil, fmt.Errorf(azure.ParamNotSpecifiedError, "cloudserviceName")
+		return nil, fmt.Errorf(paramNotSpecifiedError, "cloudserviceName")
 	}
 	if len(deploymentName) == 0 {
-		return nil, fmt.Errorf(azure.ParamNotSpecifiedError, "deploymentName")
+		return nil, fmt.Errorf(paramNotSpecifiedError, "deploymentName")
 	}
 	if len(roleName) == 0 {
-		return nil, fmt.Errorf(azure.ParamNotSpecifiedError, "roleName")
+		return nil, fmt.Errorf(paramNotSpecifiedError, "roleName")
 	}
 
 	role := new(Role)
@@ -315,13 +316,13 @@ func GetRole(cloudserviceName, deploymentName, roleName string) (*Role, error) {
 
 func StartRole(cloudserviceName, deploymentName, roleName string) error {
 	if len(cloudserviceName) == 0 {
-		return fmt.Errorf(azure.ParamNotSpecifiedError, "cloudserviceName")
+		return fmt.Errorf(paramNotSpecifiedError, "cloudserviceName")
 	}
 	if len(deploymentName) == 0 {
-		return fmt.Errorf(azure.ParamNotSpecifiedError, "deploymentName")
+		return fmt.Errorf(paramNotSpecifiedError, "deploymentName")
 	}
 	if len(roleName) == 0 {
-		return fmt.Errorf(azure.ParamNotSpecifiedError, "roleName")
+		return fmt.Errorf(paramNotSpecifiedError, "roleName")
 	}
 
 	startRoleOperation := createStartRoleOperation()
@@ -343,13 +344,13 @@ func StartRole(cloudserviceName, deploymentName, roleName string) error {
 
 func ShutdownRole(cloudserviceName, deploymentName, roleName string) error {
 	if len(cloudserviceName) == 0 {
-		return fmt.Errorf(azure.ParamNotSpecifiedError, "cloudserviceName")
+		return fmt.Errorf(paramNotSpecifiedError, "cloudserviceName")
 	}
 	if len(deploymentName) == 0 {
-		return fmt.Errorf(azure.ParamNotSpecifiedError, "deploymentName")
+		return fmt.Errorf(paramNotSpecifiedError, "deploymentName")
 	}
 	if len(roleName) == 0 {
-		return fmt.Errorf(azure.ParamNotSpecifiedError, "roleName")
+		return fmt.Errorf(paramNotSpecifiedError, "roleName")
 	}
 
 	shutdownRoleOperation := createShutdowRoleOperation()
@@ -371,13 +372,13 @@ func ShutdownRole(cloudserviceName, deploymentName, roleName string) error {
 
 func RestartRole(cloudserviceName, deploymentName, roleName string) error {
 	if len(cloudserviceName) == 0 {
-		return fmt.Errorf(azure.ParamNotSpecifiedError, "cloudserviceName")
+		return fmt.Errorf(paramNotSpecifiedError, "cloudserviceName")
 	}
 	if len(deploymentName) == 0 {
-		return fmt.Errorf(azure.ParamNotSpecifiedError, "deploymentName")
+		return fmt.Errorf(paramNotSpecifiedError, "deploymentName")
 	}
 	if len(roleName) == 0 {
-		return fmt.Errorf(azure.ParamNotSpecifiedError, "roleName")
+		return fmt.Errorf(paramNotSpecifiedError, "roleName")
 	}
 
 	restartRoleOperation := createRestartRoleOperation()
@@ -399,13 +400,13 @@ func RestartRole(cloudserviceName, deploymentName, roleName string) error {
 
 func DeleteRole(cloudserviceName, deploymentName, roleName string) error {
 	if len(cloudserviceName) == 0 {
-		return fmt.Errorf(azure.ParamNotSpecifiedError, "cloudserviceName")
+		return fmt.Errorf(paramNotSpecifiedError, "cloudserviceName")
 	}
 	if len(deploymentName) == 0 {
-		return fmt.Errorf(azure.ParamNotSpecifiedError, "deploymentName")
+		return fmt.Errorf(paramNotSpecifiedError, "deploymentName")
 	}
 	if len(roleName) == 0 {
-		return fmt.Errorf(azure.ParamNotSpecifiedError, "roleName")
+		return fmt.Errorf(paramNotSpecifiedError, "roleName")
 	}
 
 	requestURL := fmt.Sprintf(azureRoleURL, cloudserviceName, deploymentName, roleName)
@@ -436,7 +437,7 @@ func GetRoleSizeList() (RoleSizeList, error) {
 
 func ResolveRoleSize(roleSizeName string) error {
 	if len(roleSizeName) == 0 {
-		return fmt.Errorf(azure.ParamNotSpecifiedError, "roleSizeName")
+		return fmt.Errorf(paramNotSpecifiedError, "roleSizeName")
 	}
 
 	roleSizeList, err := GetRoleSizeList()
@@ -764,7 +765,7 @@ next:
 
 func isInstanceSizeAvailableInLocation(location *locationClient.Location, instanceSize string) (bool, error) {
 	if len(instanceSize) == 0 {
-		return false, fmt.Errorf(azure.ParamNotSpecifiedError, "vmSize")
+		return false, fmt.Errorf(paramNotSpecifiedError, "vmSize")
 	}
 
 	for _, availableRoleSize := range location.VirtualMachineRoleSizes {

--- a/clients/vmDiskClient/vmDiskClient.go
+++ b/clients/vmDiskClient/vmDiskClient.go
@@ -6,14 +6,15 @@ import (
 )
 
 const (
-	azureVMDiskURL = "services/disks/%s"
+	azureVMDiskURL         = "services/disks/%s"
+	paramNotSpecifiedError = "Parameter %s is not specified."
 )
 
 //Region public methods starts
 
 func DeleteDisk(diskName string) error {
 	if len(diskName) == 0 {
-		return fmt.Errorf(azure.ParamNotSpecifiedError, "diskName")
+		return fmt.Errorf(paramNotSpecifiedError, "diskName")
 	}
 
 	requestURL := fmt.Sprintf(azureVMDiskURL, diskName)

--- a/common.go
+++ b/common.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	ParamNotSpecifiedError = "Parameter %s is not specified."
+	paramNotSpecifiedError = "Parameter %s is not specified."
 
 	azureManagementDnsName = "https://management.core.windows.net"
 	msVersionHeader        = "x-ms-version"
@@ -29,7 +29,7 @@ const (
 
 func SendAzureGetRequest(url string) ([]byte, error) {
 	if len(url) == 0 {
-		return nil, fmt.Errorf(ParamNotSpecifiedError, "url")
+		return nil, fmt.Errorf(paramNotSpecifiedError, "url")
 	}
 
 	response, err := SendAzureRequest(url, "GET", nil)
@@ -43,7 +43,7 @@ func SendAzureGetRequest(url string) ([]byte, error) {
 
 func SendAzurePostRequest(url string, data []byte) (string, error) {
 	if len(url) == 0 {
-		return "", fmt.Errorf(ParamNotSpecifiedError, "url")
+		return "", fmt.Errorf(paramNotSpecifiedError, "url")
 	}
 
 	response, err := SendAzureRequest(url, "POST", data)
@@ -57,7 +57,7 @@ func SendAzurePostRequest(url string, data []byte) (string, error) {
 
 func SendAzureDeleteRequest(url string) (string, error) {
 	if len(url) == 0 {
-		return "", fmt.Errorf(ParamNotSpecifiedError, "url")
+		return "", fmt.Errorf(paramNotSpecifiedError, "url")
 	}
 
 	response, err := SendAzureRequest(url, "DELETE", nil)
@@ -71,10 +71,10 @@ func SendAzureDeleteRequest(url string) (string, error) {
 
 func SendAzureRequest(url string, requestType string, data []byte) (*http.Response, error) {
 	if len(url) == 0 {
-		return nil, fmt.Errorf(ParamNotSpecifiedError, "url")
+		return nil, fmt.Errorf(paramNotSpecifiedError, "url")
 	}
 	if len(requestType) == 0 {
-		return nil, fmt.Errorf(ParamNotSpecifiedError, "requestType")
+		return nil, fmt.Errorf(paramNotSpecifiedError, "requestType")
 	}
 
 	client := createHttpClient()
@@ -89,7 +89,7 @@ func SendAzureRequest(url string, requestType string, data []byte) (*http.Respon
 
 func ExecuteCommand(command string, input []byte) ([]byte, error) {
 	if len(command) == 0 {
-		return nil, fmt.Errorf(ParamNotSpecifiedError, "command")
+		return nil, fmt.Errorf(paramNotSpecifiedError, "command")
 	}
 
 	parts := strings.Fields(command)
@@ -111,7 +111,7 @@ func ExecuteCommand(command string, input []byte) ([]byte, error) {
 
 func GetOperationStatus(operationId string) (*Operation, error) {
 	if len(operationId) == 0 {
-		return nil, fmt.Errorf(ParamNotSpecifiedError, "operationId")
+		return nil, fmt.Errorf(paramNotSpecifiedError, "operationId")
 	}
 
 	operation := new(Operation)
@@ -131,7 +131,7 @@ func GetOperationStatus(operationId string) (*Operation, error) {
 
 func WaitAsyncOperation(operationId string) error {
 	if len(operationId) == 0 {
-		return fmt.Errorf(ParamNotSpecifiedError, "operationId")
+		return fmt.Errorf(paramNotSpecifiedError, "operationId")
 	}
 
 	status := "InProgress"
@@ -156,7 +156,7 @@ func WaitAsyncOperation(operationId string) error {
 
 func CheckStringParams(url string) ([]byte, error) {
 	if len(url) == 0 {
-		return nil, fmt.Errorf(ParamNotSpecifiedError, "url")
+		return nil, fmt.Errorf(paramNotSpecifiedError, "url")
 	}
 
 	response, err := SendAzureRequest(url, "GET", nil)

--- a/publishSettings.go
+++ b/publishSettings.go
@@ -22,10 +22,10 @@ func setPublishSettings(id string, cert []byte, key []byte) {
 
 func ImportPublishSettings(id string, certPath string) error {
 	if len(id) == 0 {
-		return fmt.Errorf(ParamNotSpecifiedError, "id")
+		return fmt.Errorf(paramNotSpecifiedError, "id")
 	}
 	if len(certPath) == 0 {
-		return fmt.Errorf(ParamNotSpecifiedError, "certPath")
+		return fmt.Errorf(paramNotSpecifiedError, "certPath")
 	}
 
 	cert, err := ioutil.ReadFile(certPath)
@@ -39,7 +39,7 @@ func ImportPublishSettings(id string, certPath string) error {
 
 func ImportPublishSettingsFile(filePath string) error {
 	if len(filePath) == 0 {
-		return fmt.Errorf(ParamNotSpecifiedError, "filePath")
+		return fmt.Errorf(paramNotSpecifiedError, "filePath")
 	}
 
 	publishSettingsContent, err := ioutil.ReadFile(filePath)
@@ -63,17 +63,17 @@ func ImportPublishSettingsFile(filePath string) error {
 
 func getSubscriptionCert(subscription subscription) ([]byte, error) {
 	certPassword := ""
-	
+
 	pfxCert, err := base64.StdEncoding.DecodeString(subscription.ManagementCertificate)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	subscriptionCert, err := ExecuteCommand(fmt.Sprintf("openssl pkcs12 -nodes -passin pass:%s", certPassword), pfxCert)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return subscriptionCert, nil
 }
 


### PR DESCRIPTION
As discussed during #26.

This necessitates duplication of the error message across the various different packages, however for the cleanliness of the API this seems worthwhile given that the error messages should likely not be localized anyway.