### PR TITLE
Add method on entities for concatenating locations

### DIFF
--- a/clients/locationClient/entities.go
+++ b/clients/locationClient/entities.go
@@ -1,7 +1,10 @@
 package locationClient
 
 import (
+	"bytes"
 	"encoding/xml"
+	"fmt"
+	"strings"
 )
 
 type LocationList struct {
@@ -16,4 +19,14 @@ type Location struct {
 	AvailableServices       []string `xml:"AvailableServices>AvailableService"`
 	WebWorkerRoleSizes      []string `xml:"ComputeCapabilities>WebWorkerRoleSizes>RoleSize"`
 	VirtualMachineRoleSizes []string `xml:"ComputeCapabilities>VirtualMachinesRoleSizes>RoleSize"`
+}
+
+func (locationList LocationList) String() string {
+	var buf bytes.Buffer
+
+	for _, location := range locationList.Locations {
+		buf.WriteString(fmt.Sprintf("%s, ", location.Name))
+	}
+
+	return strings.Trim(buf.String(), ", ")
 }

--- a/clients/locationClient/locationClient.go
+++ b/clients/locationClient/locationClient.go
@@ -1,12 +1,10 @@
 package locationClient
 
 import (
-	"bytes"
 	"encoding/xml"
 	"errors"
 	"fmt"
 	azure "github.com/MSOpenTech/azure-sdk-for-go"
-	"strings"
 )
 
 const (
@@ -32,12 +30,7 @@ func ResolveLocation(location string) error {
 		return nil
 	}
 
-	var availableLocations bytes.Buffer
-	for _, existingLocation := range locations.Locations {
-		availableLocations.WriteString(existingLocation.Name + ", ")
-	}
-
-	return errors.New(fmt.Sprintf(invalidLocationError, location, strings.Trim(availableLocations.String(), ", ")))
+	return errors.New(fmt.Sprintf(invalidLocationError, location, locations.String()))
 }
 
 func GetLocationList() (LocationList, error) {
@@ -74,10 +67,5 @@ func GetLocation(location string) (*Location, error) {
 		return &existingLocation, nil
 	}
 
-	var availableLocations bytes.Buffer
-	for _, existingLocation := range locations.Locations {
-		availableLocations.WriteString(existingLocation.Name + ", ")
-	}
-
-	return nil, errors.New(fmt.Sprintf(invalidLocationError, location, strings.Trim(availableLocations.String(), ", ")))
+	return nil, errors.New(fmt.Sprintf(invalidLocationError, location, locations.String()))
 }

--- a/clients/locationClient/locationClient.go
+++ b/clients/locationClient/locationClient.go
@@ -30,7 +30,7 @@ func ResolveLocation(location string) error {
 		return nil
 	}
 
-	return errors.New(fmt.Sprintf(invalidLocationError, location, locations.String()))
+	return errors.New(fmt.Sprintf(invalidLocationError, location, locations))
 }
 
 func GetLocationList() (LocationList, error) {
@@ -67,5 +67,5 @@ func GetLocation(location string) (*Location, error) {
 		return &existingLocation, nil
 	}
 
-	return nil, errors.New(fmt.Sprintf(invalidLocationError, location, locations.String()))
+	return nil, errors.New(fmt.Sprintf(invalidLocationError, location, locations))
 }


### PR DESCRIPTION
As discussed in #26.

This eliminates some repetition in the location client by implementing Stringer on a LocationList as a comma separated list of the location names.