### PR TITLE
Separate the Hosted Service Client from VM Client

### DIFF
--- a/clients/hostedServiceClient/entities.go
+++ b/clients/hostedServiceClient/entities.go
@@ -1,0 +1,21 @@
+package hostedServiceClient
+
+import (
+	"encoding/xml"
+)
+
+type HostedServiceDeployment struct {
+	XMLName        xml.Name `xml:"CreateHostedService"`
+	Xmlns          string   `xml:"xmlns,attr"`
+	ServiceName    string
+	Label          string
+	Description    string
+	Location       string
+	ReverseDnsFqdn string `xml:"omitempty"`
+}
+
+type AvailabilityResponse struct {
+	Xmlns  string `xml:"xmlns,attr"`
+	Result bool
+	Reason string
+}

--- a/clients/hostedServiceClient/hostedServiceClient.go
+++ b/clients/hostedServiceClient/hostedServiceClient.go
@@ -1,0 +1,128 @@
+package hostedServiceClient
+
+import (
+	"encoding/base64"
+	"encoding/xml"
+	"fmt"
+
+	azure "github.com/MSOpenTech/azure-sdk-for-go"
+	"github.com/MSOpenTech/azure-sdk-for-go/clients/locationClient"
+)
+
+const (
+	azureXmlns                        = "http://schemas.microsoft.com/windowsazure"
+	azureDeploymentListURL            = "services/hostedservices/%s/deployments"
+	azureHostedServiceListURL         = "services/hostedservices"
+	deleteAzureHostedServiceURL       = "services/hostedservices/%s?comp=media"
+	azureHostedServiceAvailabilityURL = "services/hostedservices/operations/isavailable/%s"
+	azureDeploymentURL                = "services/hostedservices/%s/deployments/%s"
+	deleteAzureDeploymentURL          = "services/hostedservices/%s/deployments/%s?comp=media"
+
+	invalidDnsLengthError = "The DNS name must be between 3 and 25 characters."
+)
+
+func CreateHostedService(dnsName, location string, reverseDnsFqdn string) (string, error) {
+	if len(dnsName) == 0 {
+		return "", fmt.Errorf(azure.ParamNotSpecifiedError, "dnsName")
+	}
+	if len(location) == 0 {
+		return "", fmt.Errorf(azure.ParamNotSpecifiedError, "location")
+	}
+
+	err := verifyDNSName(dnsName)
+	if err != nil {
+		return "", err
+	}
+
+	result, reason, err := CheckHostedServiceNameAvailability(dnsName)
+	if err != nil {
+		return "", err
+	}
+	if !result {
+		return "", fmt.Errorf("%s Hosted service name: %s", reason, dnsName)
+	}
+
+	err = locationClient.ResolveLocation(location)
+	if err != nil {
+		return "", err
+	}
+
+	hostedServiceDeployment := createHostedServiceDeploymentConfig(dnsName, location, reverseDnsFqdn)
+	hostedServiceBytes, err := xml.Marshal(hostedServiceDeployment)
+	if err != nil {
+		return "", err
+	}
+
+	requestURL := azureHostedServiceListURL
+	requestId, err := azure.SendAzurePostRequest(requestURL, hostedServiceBytes)
+	if err != nil {
+		return "", err
+	}
+
+	return requestId, nil
+}
+
+func CheckHostedServiceNameAvailability(dnsName string) (bool, string, error) {
+	if len(dnsName) == 0 {
+		return false, "", fmt.Errorf(azure.ParamNotSpecifiedError, "dnsName")
+	}
+
+	err := verifyDNSName(dnsName)
+	if err != nil {
+		return false, "", err
+	}
+
+	requestURL := fmt.Sprintf(azureHostedServiceAvailabilityURL, dnsName)
+	response, err := azure.SendAzureGetRequest(requestURL)
+	if err != nil {
+		return false, "", err
+	}
+
+	availabilityResponse := new(AvailabilityResponse)
+	err = xml.Unmarshal(response, availabilityResponse)
+	if err != nil {
+		return false, "", err
+	}
+
+	return availabilityResponse.Result, availabilityResponse.Reason, nil
+}
+
+func DeleteHostedService(dnsName string) error {
+	if len(dnsName) == 0 {
+		return fmt.Errorf(azure.ParamNotSpecifiedError, "dnsName")
+	}
+
+	err := verifyDNSName(dnsName)
+	if err != nil {
+		return err
+	}
+
+	requestURL := fmt.Sprintf(deleteAzureHostedServiceURL, dnsName)
+	requestId, err := azure.SendAzureDeleteRequest(requestURL)
+	if err != nil {
+		return err
+	}
+
+	azure.WaitAsyncOperation(requestId)
+	return nil
+}
+
+func createHostedServiceDeploymentConfig(dnsName, location string, reverseDnsFqdn string) HostedServiceDeployment {
+	deployment := HostedServiceDeployment{}
+	deployment.ServiceName = dnsName
+	label := base64.StdEncoding.EncodeToString([]byte(dnsName))
+	deployment.Label = label
+	deployment.Location = location
+	deployment.ReverseDnsFqdn = reverseDnsFqdn
+	deployment.Xmlns = azureXmlns
+
+	return deployment
+}
+
+func verifyDNSName(dns string) error {
+	if len(dns) < 3 || len(dns) > 25 {
+		return fmt.Errorf(invalidDnsLengthError)
+	}
+
+	return nil
+}

--- a/clients/vmClient/entities.go
+++ b/clients/vmClient/entities.go
@@ -14,16 +14,7 @@ type VMDeployment struct {
 	Url              string `xml:",omitempty"`
 	RoleList         RoleList
 	RoleInstanceList RoleInstanceList `xml:",omitempty"`
-	VirtualIPs       VirtualIPs `xml:",omitempty"`
-}
-
-type HostedServiceDeployment struct {
-	XMLName     xml.Name `xml:"CreateHostedService"`
-	Xmlns       string   `xml:"xmlns,attr"`
-	ServiceName string
-	Label       string
-	Description string
-	Location    string
+	VirtualIPs       VirtualIPs       `xml:",omitempty"`
 }
 
 type RoleList struct {
@@ -160,12 +151,6 @@ type ShutdownRoleOperation struct {
 type RestartRoleOperation struct {
 	Xmlns         string `xml:"xmlns,attr"`
 	OperationType string
-}
-
-type AvailabilityResponse struct {
-	Xmlns  string `xml:"xmlns,attr"`
-	Result bool
-	Reason string
 }
 
 type RoleSizeList struct {


### PR DESCRIPTION
This allows for a less confusing creation of empty cloud services (if for example one is trying to provision multiple virtual machines into the same cloud service and wants to create it first).

Also allow specification of the Reverse DNS FQDN for the cloud service upon creation (will be ommitted from the request to Azure if it's empty
as per the documentation).

At the moment the API for creating Virtual Machines does not allow them to be placed into an existing cloud service, that change will follow.