### PR TITLE
Add a client for Virtual Network management

### DIFF
--- a/clients/vnetClient/entities.go
+++ b/clients/vnetClient/entities.go
@@ -1,0 +1,81 @@
+package vnetClient
+
+import (
+	"encoding/xml"
+)
+
+const xmlNamespace = "http://schemas.microsoft.com/ServiceHosting/2011/07/NetworkConfiguration"
+const xmlNamespaceXsd = "http://www.w3.org/2001/XMLSchema"
+const xmlNamespaceXsi = "http://www.w3.org/2001/XMLSchema-instance"
+
+//NetworkConfiguration represents the network configuration for an entire Azure
+//subscription. TODO: Nicer builder methods for these that abstract away the
+//underlying structure
+type NetworkConfiguration struct {
+	XMLName         xml.Name                    `xml:"NetworkConfiguration"`
+	XmlNamespaceXsd string                      `xml:"xmlns:xsd,attr"`
+	XmlNamespaceXsi string                      `xml:"xmlns:xsi,attr"`
+	Xmlns           string                      `xml:"xmlns,attr"`
+	Configuration   VirtualNetworkConfiguration `xml:"VirtualNetworkConfiguration"`
+}
+
+//NewNetworkConfiguration creates a new empty NetworkConfiguration structure for
+//further configuration. The XML namespaces are set correctly.
+func NewNetworkConfiguration() NetworkConfiguration {
+	networkConfiguration := NetworkConfiguration{}
+	networkConfiguration.setXmlNamespaces()
+	return networkConfiguration
+}
+
+//setXmlNamespaces ensure that all of the required namespaces are set. It should
+//be called prior to marshalling the structure to XML for use with the Azure REST
+//endpoint. It is used internally prior to submitting requests, but since it is
+//idempotent there is no harm in repeat calls.
+func (self *NetworkConfiguration) setXmlNamespaces() {
+	self.XmlNamespaceXsd = xmlNamespaceXsd
+	self.XmlNamespaceXsi = xmlNamespaceXsi
+	self.Xmlns = xmlNamespace
+}
+
+type VirtualNetworkConfiguration struct {
+	Dns                 Dns                  `xml:"Dns,omitempty"`
+	LocalNetworkSites   []LocalNetworkSite   `xml:"LocalNetworkSites>LocalNetworkSite"`
+	VirtualNetworkSites []VirtualNetworkSite `xml:"VirtualNetworkSites>VirtualNetworkSite"`
+}
+
+type Dns struct {
+	DnsServers []DnsServer `xml:"DnsServers,omitempty>DnsServer,omitempty"`
+}
+
+type DnsServer struct {
+	XMLName   xml.Name `xml:"DnsServer"`
+	Name      string   `xml:"name,attr"`
+	IPAddress string   `xml:"IPAddress,attr"`
+}
+
+type DnsServerRef struct {
+	Name string `xml:"name,attr"`
+}
+
+type VirtualNetworkSite struct {
+	Name          string         `xml:"name,attr"`
+	Location      string         `xml:"Location,attr"`
+	AddressSpace  AddressSpace   `xml:"AddressSpace"`
+	Subnets       []Subnet       `xml:"Subnets>Subnet"`
+	DnsServersRef []DnsServerRef `xml:"DnsServersRef,omitempty>DnsServerRef"`
+}
+
+type LocalNetworkSite struct {
+	Name              string `xml:"name,attr"`
+	VPNGatewayAddress string
+	AddressSpace      AddressSpace
+}
+
+type AddressSpace struct {
+	AddressPrefix []string
+}
+
+type Subnet struct {
+	Name          string `xml:"name,attr"`
+	AddressPrefix string
+}

--- a/clients/vnetClient/vnetClient.go
+++ b/clients/vnetClient/vnetClient.go
@@ -1,0 +1,49 @@
+package vnetClient
+
+import (
+	"encoding/xml"
+	azure "github.com/MSOpenTech/azure-sdk-for-go"
+)
+
+const (
+	azureNetworkConfigurationURL = "services/networking/media"
+)
+
+//GetVirtualNetworkConfiguration retreives the current virtual network
+//configuration for the currently active subscription. Note that the
+//underlying Azure API means that network related operations are not safe
+//for running concurrently.
+func GetVirtualNetworkConfiguration() (NetworkConfiguration, error) {
+	networkConfiguration := NewNetworkConfiguration()
+	response, err := azure.SendAzureGetRequest(azureNetworkConfigurationURL)
+	if err != nil {
+		return networkConfiguration, err
+	}
+
+	err = xml.Unmarshal(response, &networkConfiguration)
+	if err != nil {
+		return networkConfiguration, err
+	}
+
+	return networkConfiguration, nil
+}
+
+//SetVirtualNetworkConfiguration configures the virtual networks for the
+//currently active subscription according to the NetworkConfiguration given.
+//Note that the underlying Azure API means that network related operations
+//are not safe for running concurrently.
+func SetVirtualNetworkConfiguration(networkConfiguration NetworkConfiguration) error {
+	networkConfiguration.setXmlNamespaces()
+	networkConfigurationBytes, err := xml.Marshal(networkConfiguration)
+	if err != nil {
+		return err
+	}
+
+	requestId, err := azure.SendAzurePutRequest(azureNetworkConfigurationURL, "text/plain", networkConfigurationBytes)
+	if err != nil {
+		return err
+	}
+
+	err = azure.WaitAsyncOperation(requestId)
+	return err
+}


### PR DESCRIPTION
This pull requests support for managing virtual networks in Azure.

It adds structs to parse and generate the (seemingly unavailable) XML schema for virtual network specification, and a client with Get and Set operations for the currently active subscription.

The pattern for using the client is the same as the powershell version - get the running config, merge in any desired changes and set the configuration to the new state. There is no documentation on what the concurrency constraints are with the underlying Azure REST API, I suspect it is not safe to call concurrently though can't verify this.

It was also necessary to modify the HTTP client to accept different content types, since the underlying REST API requires the PUT operation to be made with a content type of `text/plain`, despite it actually being XML.