### PR TITLE
Replace openssl dependency with pure go implementation for converting

### DIFF
--- a/management/util.go
+++ b/management/util.go
@@ -1,35 +1,9 @@
 package management
 
 import (
-	"bytes"
-	"fmt"
 	"github.com/MSOpenTech/azure-sdk-for-go/core/http"
 	"io"
-	"os/exec"
-	"strings"
 )
-
-func executeCommand(command string, input []byte) ([]byte, error) {
-	if command == "" {
-		return nil, fmt.Errorf(errParamNotSpecified, "command")
-	}
-
-	parts := strings.Fields(command)
-	head := parts[0]
-	parts = parts[1:len(parts)]
-
-	cmd := exec.Command(head, parts...)
-	if input != nil {
-		cmd.Stdin = bytes.NewReader(input)
-	}
-
-	out, err := cmd.Output()
-	if err != nil {
-		return nil, err
-	}
-
-	return out, nil
-}
 
 func getResponseBody(response *http.Response) []byte {
 	responseBody := make([]byte, response.ContentLength)


### PR DESCRIPTION
I implemented PKCS12 from the RFC's to read PFX files. With this, we can drop the implicit openssl dependency.

cc: @ahmetalpbalkan 