### PR TITLE
Take HTTP proxy from environment

### DIFF
--- a/management/http.go
+++ b/management/http.go
@@ -111,6 +111,7 @@ func (client *Client) createHttpClient() *http.Client {
 
 	httpClient := &http.Client{
 		Transport: &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: ssl,
 		},
 	}


### PR DESCRIPTION
Allows usage of tools like Fiddler for debugging. This is the standard
way of determining the proxy.

Signed-off-by: Paul Meyer <paul.meyer@microsoft.com>