### PR TITLE
Use container build infra on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 language: go
 go: tip
 script:


### PR DESCRIPTION
See http://docs.travis-ci.com/user/workers/container-based-infrastructure/ for details. Will make builds start faster. Also, Travis seems to have more capacity for container based builds than for VM based (capped at 500?).