### PR TITLE
Fix omit empty in hosted service entities

### DIFF
--- a/management/hostedservice/entities.go
+++ b/management/hostedservice/entities.go
@@ -18,7 +18,7 @@ type CreateHostedService struct {
 	Label          string
 	Description    string
 	Location       string
-	ReverseDnsFqdn string `xml:"omitempty"`
+	ReverseDnsFqdn string `xml:",omitempty"`
 }
 
 type AvailabilityResponse struct {
@@ -44,7 +44,7 @@ type CertificateFile struct {
 	Xmlns             string `xml:"xmlns,attr"`
 	Data              string
 	CertificateFormat CertificateFormat
-	Password          string `xml:"omitempty"`
+	Password          string `xml:",omitempty"`
 }
 
 type CertificateFormat string


### PR DESCRIPTION
These fields were _named_ omitempty instead of being omitted when empty.