### PR TITLE
Enable update role scenario for resource extensions

### DIFF
--- a/management/virtualmachine/entities.go
+++ b/management/virtualmachine/entities.go
@@ -222,8 +222,8 @@ type VirtualIP struct {
 
 // Contains the configuration sets that are used to create virtual machines.
 type Role struct {
-	RoleName                    string                        // Specifies the name for the Virtual Machine.
-	RoleType                    string                        // Specifies the type of role to use. For Virtual Machines, this must be PersistentVMRole.
+	RoleName                    string                        `xml:",omitempty"` // Specifies the name for the Virtual Machine.
+	RoleType                    string                        `xml:",omitempty"` // Specifies the type of role to use. For Virtual Machines, this must be PersistentVMRole.
 	ConfigurationSets           *[]ConfigurationSet           `xml:"ConfigurationSets>ConfigurationSet",omitempty"`
 	ResourceExtensionReferences *[]ResourceExtensionReference `xml:"ResourceExtensionReferences>ResourceExtensionReference,omitempty"`
 	VMImageName                 string                        `xml:",omitempty"`                                         // Specifies the name of the VM Image that is to be used to create the Virtual Machine. If this element is used, the ConfigurationSets element is not used.

--- a/management/vmutils/extensions_test.go
+++ b/management/vmutils/extensions_test.go
@@ -1,0 +1,45 @@
+package vmutils
+
+import (
+	"encoding/xml"
+	"testing"
+
+	vm "github.com/MSOpenTech/azure-sdk-for-go/management/virtualmachine"
+)
+
+func Test_AddAzureVMExtensionConfiguration(t *testing.T) {
+
+	role := vm.Role{}
+	AddAzureVMExtensionConfiguration(&role,
+		"nameOfExtension", "nameOfPublisher", "versionOfExtension", "nameOfReference", "state", []byte{}, []byte{})
+
+	data, err := xml.MarshalIndent(role, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if expected := `<Role>
+  <ResourceExtensionReferences>
+    <ResourceExtensionReference>
+      <ReferenceName>nameOfReference</ReferenceName>
+      <Publisher>nameOfPublisher</Publisher>
+      <Name>nameOfExtension</Name>
+      <Version>versionOfExtension</Version>
+      <ResourceExtensionParameterValues>
+        <ResourceExtensionParameterValue>
+          <Key>ignored</Key>
+          <Value></Value>
+          <Type>Private</Type>
+        </ResourceExtensionParameterValue>
+        <ResourceExtensionParameterValue>
+          <Key>ignored</Key>
+          <Value></Value>
+          <Type>Public</Type>
+        </ResourceExtensionParameterValue>
+      </ResourceExtensionParameterValues>
+      <State>state</State>
+    </ResourceExtensionReference>
+  </ResourceExtensionReferences>
+</Role>`; string(data) != expected {
+		t.Fatalf("Expected %q, but got %q", expected, string(data))
+	}
+}


### PR DESCRIPTION
To only update the resource extensions for a role, the update role operation needs to post the Role object with just the resource extensions tag filled out. Presence of an empty role name tag is interpreted as trying to change the role name and hence will lead to an error.