### PR TITLE
If not supplying a subscription ID, it should use the first one found

### DIFF
--- a/management/publishSettings.go
+++ b/management/publishSettings.go
@@ -59,7 +59,7 @@ func ClientFromPublishSettingsFileWithConfig(filePath, subscriptionId string, co
 					managementURL = config.ManagementURL
 				}
 
-				return makeClient(subscriptionId, cert, managementURL)
+				return makeClient(sub.Id, cert, managementURL)
 			}
 		}
 	}


### PR DESCRIPTION
This didn’t work as expected as the wrong variable was passed to the `makeClient` func…